### PR TITLE
Divisionの名前を修正

### DIFF
--- a/pages/challenges.vue
+++ b/pages/challenges.vue
@@ -224,6 +224,9 @@ export default {
         "A Upper",
         "A Middle",
         "A Lower",
+        "A- Upper",
+        "A- Middle",
+        "A- Lower",
         "B+"
       ];
       return divArray[divId] || "???";


### PR DESCRIPTION
@maktopia web ui 上で一番下のDivisionが B+ になってますが、 A- Upper のはずです